### PR TITLE
Improve Communication Explore's Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - align filter pills correctly
 - sampled values icon publish is missing
+- caching extracted information to improve performance
 
 ## Changed
 - accordion is now reacting to filtered service types

--- a/packages/uilib/src/lib/components/diagram/diagram.svelte
+++ b/packages/uilib/src/lib/components/diagram/diagram.svelte
@@ -179,7 +179,7 @@
 		on:mousemove={handleMouseMove}
 		on:mouseup={handleMouseUp}
 		on:mouseleave={handleMouseLeave}
-		on:mousewheel={handleMouseWheel}
+		on:wheel={handleMouseWheel}
 		class:draggingEnabled
 		class:isDragging
 	>

--- a/packages/uilib/src/lib/plugins/communication-explorer/telemetry-view/telemetry-view.svelte
+++ b/packages/uilib/src/lib/plugins/communication-explorer/telemetry-view/telemetry-view.svelte
@@ -13,12 +13,15 @@
 	} from "../_store-view-filter"
 	import type { Config } from "../_func-layout-calculation/config"
 	import { preferences$, type Preferences  } from "../_store-preferences"
+	import type { IEDCommInfo } from "@oscd-plugins/core"
 	
 	export let root: Element
 	export let showSidebar = true
 	
 	let rootNode: RootNode | undefined = undefined
 	$: initInfos(root, $filterState, $preferences$)
+	let lastUsedRoot: Element | undefined = undefined
+	let lastExtractedInfos: IEDCommInfo[] = []
 	
 	// Note: maybe have a mutex if there are too many changes
 	async function initInfos(
@@ -31,8 +34,12 @@
 			return []
 		}
 		
-		const iedInfos = extractIEDInfos(root)
-		rootNode = await calculateLayout(iedInfos, config, selectedFilter, preferences)
+		if(root !== lastUsedRoot) {
+			const iedInfos = extractIEDInfos(root)
+			lastExtractedInfos = iedInfos
+			lastUsedRoot = root
+		}
+		rootNode = await calculateLayout(lastExtractedInfos, config, selectedFilter, preferences)
 	}
 	
 	const config: Config = {


### PR DESCRIPTION
Every time the preferences or selection changed we re-extracted all information from the XML.
Now it is cached will only re-extracted if the XML file itself changes.